### PR TITLE
Upgrade base system to Debian Bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM debian:11
+FROM debian:12
 
-ARG APT_SOURCE=https://mirrors.ustc.edu.cn
+ARG APT_SOURCE=http://mirrors.ustc.edu.cn
 ENV APT_SOURCE=$APT_SOURCE
 
-RUN sed -Ei "s,https?://(deb|security)\.debian\.org,$APT_SOURCE,g" /etc/apt/sources.list && \
+RUN sed -Ei "s,https?://(deb|security)\.debian\.org,$APT_SOURCE,g" /etc/apt/sources.list.d/debian.sources && \
     apt-get update && \
     apt-get -y upgrade && \
     apt-get install --no-install-recommends --yes \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # liimstrap
 
-中国科大图书馆图书查询机自动生成脚本，当前版本基于 Debian Bullseye 开发。
+中国科大图书馆图书查询机自动生成脚本，当前版本基于 Debian Bookworm 开发。
 
 话说，LIIMS 是嘛意思？我猜是 Library Independent Inquery Machine System 吧。
 

--- a/etc/apt/sources.list
+++ b/etc/apt/sources.list
@@ -1,3 +1,3 @@
-deb http://mirrors.ustc.edu.cn/debian/ bookworm main contrib non-free-firmware
-deb http://mirrors.ustc.edu.cn/debian-security bookworm-security main contrib non-free-firmware
-deb http://mirrors.ustc.edu.cn/debian/ bookworm-updates main contrib non-free-firmware
+deb http://mirrors.ustc.edu.cn/debian/ bookworm main contrib non-free-firmware non-free
+deb http://mirrors.ustc.edu.cn/debian-security bookworm-security main contrib non-free-firmware non-free
+deb http://mirrors.ustc.edu.cn/debian/ bookworm-updates main contrib non-free-firmware non-free

--- a/etc/apt/sources.list
+++ b/etc/apt/sources.list
@@ -1,3 +1,3 @@
-deb http://mirrors.ustc.edu.cn/debian/ bullseye main contrib non-free
-deb http://mirrors.ustc.edu.cn/debian-security bullseye-security main contrib non-free
-deb http://mirrors.ustc.edu.cn/debian/ bullseye-updates main contrib non-free
+deb http://mirrors.ustc.edu.cn/debian/ bookworm main contrib non-free-firmware
+deb http://mirrors.ustc.edu.cn/debian-security bookworm-security main contrib non-free-firmware
+deb http://mirrors.ustc.edu.cn/debian/ bookworm-updates main contrib non-free-firmware

--- a/initramfs-tools/modules
+++ b/initramfs-tools/modules
@@ -19,3 +19,6 @@ squashfs
 i915
 # QEMU
 bochs_drm
+
+# Some weird NIC
+r8168

--- a/liimstrap
+++ b/liimstrap
@@ -49,7 +49,7 @@ MIDORI_URL="${MIDORI_URL:-https://ftp.lug.ustc.edu.cn/~taoky/midori-liims_9.0-SN
 SOGOUPINYIN_URL="${SOGOUPINYIN_URL:-http://cdn2.ime.sogou.com/dl/index/1639750479/sogoupinyin_3.4.0.9700_amd64.deb}"
 
 # debootstrap
-debootstrap bullseye "$ROOT" "$APT_SOURCE/debian"
+debootstrap bookworm "$ROOT" "$APT_SOURCE/debian"
 mount -t tmpfs none "$ROOT/dev"
 chmod 755 "$ROOT/dev"
 mknod -m0666 "$ROOT/dev/null" c 1 3
@@ -78,12 +78,17 @@ install_package xterm xserver-xorg xserver-xorg-video-vesa xserver-xorg-video-no
   inetutils-telnet iptables-persistent iproute2 iputils-arping iputils-clockdiff \
   initramfs-tools libpam-systemd mtr-tiny ndisc6 netdata nyancat \
   procps rsync scrot sed ssh tar usbutils vim \
-  gnome-icon-theme gnome-themes-standard openbox slim fbpanel \
+  gnome-icon-theme gnome-themes-extra openbox slim \
   fonts-arphic-uming fonts-droid-fallback fonts-wqy-zenhei xfonts-terminus \
   fcitx fcitx-frontend-gtk2 fcitx-frontend-gtk3 \
   fcitx-pinyin fcitx-table-wubi fcitx-ui-classic \
   bash-completion curl ca-certificates jq systemd-timesyncd locales net-tools zstd \
   x11-utils dbus-x11 xfonts-base xfonts-intl-chinese x11-xserver-utils
+
+# Install fbpanel from bullseye
+wget --progress=dot:binary -O "$ROOT/tmp/fbpanel.deb" "https://mirrors.ustc.edu.cn/debian/pool/main/f/fbpanel/fbpanel_7.0-4_amd64.deb"
+check_sha256 "$ROOT/tmp/fbpanel.deb" "3ad23ecc54fb33a768c9a3c8995b3d5205eae21c06ceec121278e36241876a31"
+install_package /tmp/fbpanel.deb
 
 # Install customized midori
 wget --progress=dot:binary -O "$ROOT/tmp/midori.deb" "$MIDORI_URL"
@@ -125,7 +130,7 @@ run locale-gen
 
 # iptables
 add_file /etc/iptables/
-run systemctl enable iptables.service
+run systemctl enable netfilter-persistent.service
 
 # cron jobs
 add_file /etc/systemd/system/
@@ -181,7 +186,7 @@ rm -rf "$ROOT/usr/share/doc/"*
 add_file /etc/hosts /etc/resolv.conf /etc/apt/sources.list
 
 # cleanup
-run apt purge -y --autoremove ifupdown libfuse2 libisc-export1105 localepurge nano rsyslog tasksel
+run apt purge -y --autoremove ifupdown libfuse2 localepurge nano rsyslog tasksel
 run apt-get clean
 rm -rf "$ROOT/var"/{backups,tmp}/*
 rm -rf "$ROOT"/*.old

--- a/liimstrap
+++ b/liimstrap
@@ -170,7 +170,7 @@ echo "$VERSION" > "$ROOT/etc/liims_version"
 install -Dm644 "$BASE/initramfs-tools/initramfs.conf" "$ROOT/etc/initramfs-tools/initramfs.conf"
 install -Dm644 "$BASE/initramfs-tools/modules" "$ROOT/etc/initramfs-tools/modules"
 install -Dm755 "$BASE/initramfs-tools/scripts/init-bottom/overlay.sh" "$ROOT/etc/initramfs-tools/scripts/init-bottom/overlay.sh"
-install_package linux-image-amd64 firmware-linux
+install_package linux-image-amd64 firmware-linux firmware-realtek
 
 # Remove unused locales
 install_package localepurge

--- a/liimstrap
+++ b/liimstrap
@@ -45,7 +45,7 @@ else
 fi
 
 # External packages
-MIDORI_URL="${MIDORI_URL:-https://ftp.lug.ustc.edu.cn/~taoky/midori-liims_9.0-SNAPSHOT-1640974719_amd64.deb}"
+MIDORI_URL="${MIDORI_URL:-https://ftp.lug.ustc.edu.cn/software/liims/midori-liims_9.0-1_amd64.deb}"
 SOGOUPINYIN_URL="${SOGOUPINYIN_URL:-http://cdn2.ime.sogou.com/dl/index/1639750479/sogoupinyin_3.4.0.9700_amd64.deb}"
 
 # debootstrap
@@ -92,7 +92,7 @@ install_package /tmp/fbpanel.deb
 
 # Install customized midori
 wget --progress=dot:binary -O "$ROOT/tmp/midori.deb" "$MIDORI_URL"
-check_sha256 "$ROOT/tmp/midori.deb" "a82704e17a49071b45ccb2c7c3d4f5ecfbd2759a7942e539efd4ac4742684f4e"
+check_sha256 "$ROOT/tmp/midori.deb" "a9a64bdfb1a0a52761b041b22c0991222a627093311493e883ed8ea6a674a279"
 install_package /tmp/midori.deb
 # Install sogoupinyin
 # ref: https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=fcitx-sogoupinyin

--- a/liimstrap
+++ b/liimstrap
@@ -59,6 +59,7 @@ mknod -m0666 "$ROOT/dev/zero" c 1 5
 ln -sf /proc/self/fd/0 "$DST/dev/stdin"
 ln -sf /proc/self/fd/1 "$DST/dev/stdout"
 ln -sf /proc/self/fd/2 "$DST/dev/stderr"
+ln -sf /proc/self/fd "$ROOT/dev/"
 mkdir -p "$ROOT/dev/pts"
 mount -t devpts none "$ROOT/dev/pts"
 mount -t proc proc "$ROOT/proc"
@@ -170,7 +171,7 @@ echo "$VERSION" > "$ROOT/etc/liims_version"
 install -Dm644 "$BASE/initramfs-tools/initramfs.conf" "$ROOT/etc/initramfs-tools/initramfs.conf"
 install -Dm644 "$BASE/initramfs-tools/modules" "$ROOT/etc/initramfs-tools/modules"
 install -Dm755 "$BASE/initramfs-tools/scripts/init-bottom/overlay.sh" "$ROOT/etc/initramfs-tools/scripts/init-bottom/overlay.sh"
-install_package linux-image-amd64 firmware-linux firmware-realtek
+install_package linux-image-amd64 linux-headers-amd64 firmware-linux firmware-realtek r8168-dkms
 
 # Remove unused locales
 install_package localepurge


### PR DESCRIPTION
Some of the inquiry machines at IAT, USTC have been replaced with AIOs with 12th-gen Intel Core Processors and the i915 module in the default kernel of Debian Bulleyes cannot drive the integrated graphics. 

Upgraded the base system to Debian Bookworm and pulled the `fbpanel` package from Bullseye, seems to be OK.

Also added the `firmware-realtek` package as the machines at IAT require it.